### PR TITLE
schedule fix for today

### DIFF
--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,1 @@
+[1124/144943.883:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)

--- a/src/components/common/cards/HolidayCard.vue
+++ b/src/components/common/cards/HolidayCard.vue
@@ -1,7 +1,7 @@
 <template>
   <card>
     <img class="logo" src="static/thanksgiving.jpg" />
-    <div class="message">Have a happy Thanksgiving break! &nbsp;</div>
+    <div class="message">Have a happy Thanksgiving break!</div>
   </card>
 </template>
 

--- a/src/data/schedules.json
+++ b/src/data/schedules.json
@@ -462,7 +462,7 @@
 		]
 	},
 	{
-		"name": "Early Dismissal",
+		"name": "Early Dismissal (eL)",
 		"isSpecial": true,
 		"dates": [
 			"11/25/2020"


### PR DESCRIPTION
I found a bug relating the schedule and cookies. The schuedle showed was the one in cookies, not the updated one in the json. the thanksgiving schedule was off because It had the same name (I think).  This is for today, if you can't get to this, that is ok. I had no idea this would happen. Thanks - Joey