### PR TITLE
Fix issues with custom schedules and add documentation

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1,0 +1,114 @@
+##### *Note: Documentation is Incomplete*
+
+# Documentation
+
+### Definitions
+
+- **Schedule Type**: the type of schedule dependent on which day it is (i.e. `Standard Schedule`, `Late Arrival`, `Activity Period`, etc.)
+- **Schedule Mode**: user-selectable schedule that can apply on any given day (i.e. `Normal`, `Half Periods`). Different schedule modes can be specified based on the schedule type, for example on Late Arrival days there are no half periods, so the `Half Periods` schedule mode doesn't exist.
+
+## Format of `schedules.json`
+
+Example:
+```json
+[
+  ...,
+  {
+    "name":"Activity Period",
+    "isSpecial":true,
+    "dates":["8/14/2019","9/4/2019","10/2/2019", "10/30/2019","11/20/2019","12/2/2019","1/13/2020","2/12/2020","2/26/2020","3/18/2020","4/16/2020","4/29/2020"],
+    "modes":[
+      {
+        "name":"Normal",
+        "start":["8:30","9:20","10:06","10:54","11:40","12:26","13:12","13:58","14:44"],
+        "end":["9:15","10:01","10:49","11:35","12:21","13:07","13:53","14:39","15:25"],
+        "periods":["1","2","!Activity","3","4","5","6","7","8"]
+      },
+      {
+        "name":"Half Periods",
+        "start":["8:30","8:58","9:20","9:44","10:06","10:54","11:18","11:40","12:04","12:26","12:50","13:12","13:36","13:58","14:22","14:44","15:08"],
+        "end":["8:51","9:15","9:37","10:01","10:49","11:11","11:35","11:57","12:21","12:43","13:07","13:29","13:53","14:15","14:39","15:01","15:25"],
+        "periods":["1A","1B","2A","2B","!Activity","3A","3B","4A","4B","5A","5B","6A","6B","7A","7B","8A","8B"]
+      }
+    ]
+  },
+  ...
+]
+```
+
+The top level data structure is an array of schedules corresponding to different [schedule types](#Definitions).
+
+The `isSpecial` property is mainly used to determine whether the schedule type is important enough to appear on the Upcoming Events card as well as the Calendar. The main reason this property was created was to distinguish between No School on weekends (which we don't want to appear on the calendar) and No School for other reasons such as Teacher Institute Day (which should appear on calendar).
+
+The `dates` array specifies the dates on which they given schedule type active in a [special format](#Date%20Format). If there are conficting schedules on a given day (e.g. two different schedules have March 3rd in `dates`), then **the schedule specified later in the top level array takes priority**. This allows us to have the schedule corresponding to `Standard Schedule` be the first element in the array and be active on **all** dates, and any schedules specified later will override `Standard Schedule` on their specific days. Notice that the `No School (Weekend)` schedule has the dates `weekends` and is the last schedule in the array, which guarantees that it will be active on all weekends.
+
+Schedules also contain a `modes` array that defines all of the [schedule modes](#Definitions) that apply on the given schedule type. The schedule mode object contains the properties `start` and `end` which specify the start and end times of each period in 24-hour time. `periods` contains the name of each period. By default, when the period is displayed, it will be prefixed by "Period ", but in certain cases this behavior is not desired (we don't want "Period Assembly"). To avoid this, the period can be specified with a "!" before it (e.g. "!Assembly"). Also, if there are no modes specified, it indicates that there's no school on days with that schedule type.
+
+Lastly, the `periods` array can also be a 2D array, in which case each sub-array defines the periods for the nth consecutive day of the given schedule type. For example, on the schedule type `Finals`, we have this:
+```json
+"periods": [
+  ["1","2","4"],
+  ["3","7","5"],
+  ["8","6","!Makeup"]
+]
+```
+so the periods `["1","2","4"]` apply on the first day of finals, `["3","7","5"]` on the second, and so on.
+
+### Date Format
+
+The dates specified in `schedules.json` use a special format to make it more convenient for manual date entry. It's **whitespace agnostic** and **case-insensitive**, with the following structure:
+
+#### Dates:
+
+- `m/d/yyyy`: selects a specific date
+- `m/d`: selects that date every year
+- `d`: selects that day every month
+- `yyyy`: selects every day in that year
+- `*`: selects all days
+
+#### Keywords:
+
+- Type: `weekend`, `weekday`
+- Days of Week: `Monday`, `Tuesday`, ... 
+- Months: `January`, `February`, ...
+
+(all keywords may include an optional "s" at the end, e.g. `weekends`)
+
+#### Operators:
+
+- `-`: selects a range of dates between two dates/keywords (inclusive)
+  - `12/22/17-1/7/18` selects all dates between 12/22/17 and 1/7/18
+  - `Monday-Wednesday` selects all Mondays, Tuesdays, and Wednesdays
+  - *Note: Cannot do `Saturday-Sunday` or `December-January` (must stay in same week/year)*
+
+- `&`: **AND**, date needs to satisfy all conditions separated by it
+  - `12/22/17-1/7/18 & weekdays` selects all weekdays between 12/22/17 and 1/7/18
+
+- `|`: **OR**, date needs to satisfy one of the conditions separated by it (higher precedence than &)
+  - `12/22/17-1/7/18 & Tuesday|Thursday` selects all Tuesdays and Thursdays between 12/22/17 and 1/7/18
+
+- `!`: **NOT**, inverts the selection (higher precedence than & and |)
+  - `12/22/17-1/7/18 & !Sunday & !Saturday` selects all weekdays between 12/22/17 and 1/7/18
+
+- `n(st/nd/rd/th)`, `last`: selects the nth keyword (type or days of week) in the month
+  - `3rd monday & January` selects the 3rd Monday of January
+  - `last Friday` selects the last Friday of every month
+
+## Custom Schedules
+
+The app allows users to define their own custom schedule modes on the settings page. It also allows modification of schedules, but if the schedule being modified is an offical one (not custom), a copy will be created instead of directly modifying the original. These new schedules are saved JSON encoded in `localStorage.customSchedules`. The format for these is slightly different from `schedules.json` in order to allow for efficent merging of the custom schedules and the official ones. It's a map with the schedule type as keys and an array of schedule mode objects as values.
+
+Example:
+```json
+{
+  "Late Arrival": [
+    {
+      "name":"My Schedule",
+      "start": ["10:30","11:10","11:45","12:20","13:00","13:40","14:20","14:55"],
+      "end": ["11:05","11:40","12:15","12:55","13:35","14:15","14:50","15:25"],
+      "periods": ["Physics","Calculus","English","Lunch","Computer Science","Dance","U.S. History","Computer Art 1"],
+    },
+    ...
+  ]
+}
+```

--- a/src/components/Bell Schedules/BellSchedules.vue
+++ b/src/components/Bell Schedules/BellSchedules.vue
@@ -17,13 +17,13 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
+import { mapGetters } from 'vuex';
 import HomeLink from 'common/HomeLink.vue';
 import Schedule from './Schedule.vue';
 
 export default {
   components: { Schedule, HomeLink },
-  computed: mapState([
+  computed: mapGetters([
     'schedules',
   ]),
 };

--- a/src/components/Settings/General.vue
+++ b/src/components/Settings/General.vue
@@ -1,8 +1,8 @@
 <template>
   <settings-section title="General">
     <div class="dropdown-row">
-      <span class="title">Default Schedule:</span>
-      <dropdown class="dropdown-select" :options="allModes" :value="defaultMode" @input="updateDefaultSchedule" />
+      <span class="title">Default Schedule Mode:</span>
+      <dropdown class="dropdown-select" :options="allModes" :value="defaultMode" @input="updateDefaultScheduleMode" />
     </div>
 
     <div class="dropdown-row">
@@ -21,7 +21,7 @@
 <script>
 import Dropdown from 'common/Dropdown.vue';
 
-import { mapState } from 'vuex';
+import { mapGetters, mapState } from 'vuex';
 import SettingsSection from './SettingsSection.vue';
 
 export default {
@@ -33,9 +33,11 @@ export default {
   },
   computed: {
     ...mapState([
-      'schedules',
-      'defaultSchedule',
+      'defaultScheduleMode',
       'grade',
+    ]),
+    ...mapGetters([
+      'schedules',
     ]),
     allModes() {
       return this.schedules.reduce((arr, schedule) => {
@@ -46,7 +48,7 @@ export default {
       }, []);
     },
     defaultMode() {
-      const mode = this.allModes.indexOf(this.defaultSchedule);
+      const mode = this.allModes.indexOf(this.defaultScheduleMode);
       return mode === -1 ? 0 : mode;
     },
     selectedGrade() {
@@ -55,8 +57,8 @@ export default {
     },
   },
   methods: {
-    updateDefaultSchedule(scheduleIndex) {
-      this.$store.commit('setDefaultSchedule', this.allModes[scheduleIndex]);
+    updateDefaultScheduleMode(scheduleIndex) {
+      this.$store.commit('setDefaultScheduleMode', this.allModes[scheduleIndex]);
     },
     updateGrade(gradeIndex) {
       this.$store.commit('setGrade', this.grades[gradeIndex]);

--- a/src/components/Settings/Schedules.vue
+++ b/src/components/Settings/Schedules.vue
@@ -14,12 +14,14 @@
         :title="schedule.name"
       >
         <div class="actions">
-          <div class="action" @click="deleteSchedule(schedule.name)">
-            <font-awesome-icon :icon="icons.faTrashAlt" /> Delete
+          <div v-if="schedule.isCustom" class="action" @click="deleteSchedule(schedule.name)">
+            <font-awesome-icon :icon="icons.faTrashAlt" />
+            Delete
           </div>
 
           <div class="action" @click="editSchedule(schedule.name)">
-            <font-awesome-icon :icon="icons.faPencilAlt" /> Edit
+            <font-awesome-icon :icon="icons.faPencilAlt" />
+            {{ schedule.isCustom ? 'Edit' : 'Copy & Edit' }}
           </div>
         </div>
       </schedule-card>
@@ -37,7 +39,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
+import { mapGetters, mapActions } from 'vuex';
 
 import FontAwesomeIcon from '@fortawesome/vue-fontawesome';
 import { faPlus, faPencilAlt, faTrashAlt, faHistory } from '@fortawesome/free-solid-svg-icons';
@@ -71,7 +73,7 @@ export default {
     };
   },
   computed: {
-    ...mapState([
+    ...mapGetters([
       'schedules',
     ]),
     scheduleModes() {
@@ -96,10 +98,13 @@ export default {
     },
   },
   methods: {
+    ...mapActions([
+      'removeCustomScheduleMode'
+    ]),
     deleteSchedule(name) {
       this.$refs['confirm-popup'].displayPopup(`Are you sure you want to delete the schedule '${name}'`)
         .then(() => {
-          this.$store.commit('removeScheduleMode', { scheduleToRemove: name });
+          this.removeCustomScheduleMode({ scheduleToRemove: name });
         }, () => {
           // don't need to do anything if the user cancels
         });

--- a/src/components/Settings/Transfer.vue
+++ b/src/components/Settings/Transfer.vue
@@ -79,7 +79,7 @@ import SettingsSection from './SettingsSection.vue';
 
 const tranferableSettings = [ // the following strings should be direct properties of $store.state
   'color',
-  'defaultSchedule',
+  'defaultScheduleMode',
   'grade',
   'schedules',
 ];
@@ -127,7 +127,7 @@ export default {
     });
   },
   methods: {
-    settingToName(setting) { // convert setting to readable name ('defaultSchedule' to 'Default Schedule')
+    settingToName(setting) { // convert setting to readable name ('defaultScheduleMode' to 'Default Schedule Mode')
       const separatedWords = setting.replace(/([a-z])([A-Z])/g, '$1 $2'); // 'defaultScheduleSomething' to 'default Schedule Something'
       return separatedWords[0].toUpperCase() + separatedWords.slice(1); // capitalize first letter
     },
@@ -214,7 +214,7 @@ export default {
       if (this.receivedData) {
         for (const [setting, data] of Object.entries(this.receivedData)) {
           if (this.shouldSaveSetting[setting]) {
-            const mutation = `set${setting[0].toUpperCase()}${setting.slice(1)}`; // 'defaultSchedule' -> 'setDefaultSchedule'
+            const mutation = `set${setting[0].toUpperCase()}${setting.slice(1)}`; // 'defaultScheduleMode' -> 'setDefaultScheduleMode'
             this.$store.commit(mutation, data);
           }
         }

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -1,0 +1,8 @@
+
+export function getNameWithoutConflicts(name, doesNameExistFunction) {
+  let newName = name;
+  for (let i = 2; doesNameExistFunction(newName); i++) {
+    newName = `${name} ${i}`;
+  }
+  return newName;
+}

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -8,4 +8,31 @@ export default {
   countdownDone({ commit }) {
     commit('setCurrentTime');
   },
+  addCustomScheduleMode({ commit, state }, { scheduleType, scheduleToAdd, scheduleToReplace }) {
+    // If scheduleToReplace is not defined, then we want to just add to end of scheduleModes list
+    const scheduleModes = (state.customSchedules || {})[scheduleType] || [];
+    const replaceIndex = scheduleModes.map(mode => mode.name).indexOf(scheduleToReplace);
+    // Notice that scheduleModes only contains schedules from customSchedules, so if scheduleToReplace is an
+    // official schedule, then replaceIndex will be -1, and we'll just add the new schedule without replacing anything
+    // (this is the expected behavior because official schedules can't be modified or replaced)
+    if (replaceIndex !== -1) {
+      scheduleModes.splice(replaceIndex, 1, scheduleToAdd);
+    } else {
+      scheduleModes.push(scheduleToAdd);
+    }
+
+    commit('setCustomSchedules', { ...state.customSchedules, [scheduleType]: scheduleModes });
+  },
+  removeCustomScheduleMode({ commit, state }, { scheduleType, scheduleToRemove }) {
+    // if scheduleType is not provided, then we remove scheduleToRemove for all schedule types
+    for (const [type, scheduleModes] of Object.entries(state.customSchedules || {})) {
+      if (!scheduleType || scheduleType === type) {
+        const removeIndex = scheduleModes.map(mode => mode.name).indexOf(scheduleToRemove);
+        if (removeIndex > -1) {
+          scheduleModes.splice(removeIndex, 1);
+        }
+      }
+    }
+    commit('setCustomSchedules', state.customSchedules);
+  }
 };

--- a/src/store/initializeStore.js
+++ b/src/store/initializeStore.js
@@ -1,4 +1,3 @@
-import defaultSchedules from 'src/data/schedules.json';
 import { query } from 'vue-analytics';
 
 export default function (store) {
@@ -9,13 +8,14 @@ export default function (store) {
     query('set', 'dimension1', 'unset');
   }
 
-  const localSchedules = localStorage.schedules ? tryParseJSON(localStorage.schedules) : null;
-  const schedules = Array.isArray(localSchedules) ? localSchedules : defaultSchedules;
-  setSchedules(store, schedules);
+  store.commit('setCustomSchedules', tryParseJSON(localStorage.customSchedules));
 
-  if (localStorage.defaultSchedule) {
-    store.commit('setDefaultSchedule', localStorage.defaultSchedule);
-    store.commit('setScheduleMode', localStorage.defaultSchedule);
+  // defaultScheduleMode used to (innapropriately) be called defaultSchedule, so to preserve backwards compatibility:
+  localStorage.defaultScheduleMode = localStorage.defaultSchedule; // TODO: remove during or after summer 2021
+
+  if (localStorage.defaultScheduleMode) {
+    store.commit('setDefaultScheduleMode', localStorage.defaultScheduleMode);
+    store.commit('setScheduleMode', localStorage.defaultScheduleMode);
   }
 
   if (localStorage.grade) {
@@ -27,44 +27,7 @@ function tryParseJSON(json) {
   try {
     return JSON.parse(json);
   } catch (e) {
-    return null;
+    return {};
   }
 }
 
-// Merges localStorage schedules and defaultSchedules (from server) together in case changes have been made to defaultSchedules
-// (for example, when dates are updated or a new schedule type is added)
-// Assumptions: user cannot modify schedule types (only modes), so schedule types will always match server
-function setSchedules(store, localSchedules) {
-  let schedules = localSchedules.slice(0); // the .slice(0) (cloning array) is probably unnecessary, but just in case
-  const scheduleTypes = schedules.map(schedule => schedule.name);
-
-  // Replace all local dates with ones from the server (defaultSchedules) in case modifications were made
-  defaultSchedules.forEach((schedule) => {
-    const index = scheduleTypes.indexOf(schedule.name);
-    if (index > -1) {
-      schedules[index].dates = schedule.dates;
-    }
-  });
-
-  // Delete any schedules in the local copy that aren't found in the sever copy
-  const defaultScheduleTypes = defaultSchedules.map(schedule => schedule.name);
-  schedules = schedules.filter(schedule => defaultScheduleTypes.includes(schedule.name));
-
-  // Add any new schedules that were added to the server copy to the local one
-  defaultSchedules.forEach((schedule, index) => {
-    if (!scheduleTypes.includes(schedule.name)) { // means new schedule type was added (found in server copy but not in local)
-      schedules.splice(index, 0, schedule); // add the new schedule to schedules in the correct index
-    }
-  });
-
-  // So now the schedules on the server should match those on local (the content may be different if the user edited anything)
-  // Sort the schedules on the local copy to match the order on the server
-  const sortedSchedules = [];
-  defaultSchedules.forEach((defaultSchedule) => {
-    sortedSchedules.push( // find the local schedule with the same name as the server one and add it (in order)
-      schedules.find(schedule => defaultSchedule.name === schedule.name),
-    );
-  });
-
-  store.commit('setSchedules', sortedSchedules);
-}


### PR DESCRIPTION
Previously, when custom schedules were added, an entire copy of the schedules object (from `schedules.json`) with the modifications applied would be saved in `localStorage`. And when there were changes to the official schedules (`schedules.json`), we would try to intelligently merge the two schedules together, trying to both apply the most recent changes from us and preserve the user's modifications. However, this does not work well when there are user modifications to the specific schedule mode we want to change, in which case we chose to preserve the user modifications and the schedule would not be updated.

Now, we don't allow the user to make any modifications to official schedules and instead only allow creating new schedules. Clicking on edit for an official schedule will instead create a copy and edit that. This allows the user's custom schedules to be completely separate from the official ones and instead of storing an entire copy of schedules in `localStorage`, we now only store `customSchedules`. And instead of having `schedules` be part of the state, it's now computed by merging `officialSchedules` and `customSchedules` (very easy to merge this time since they're completely disjoint).

Also started to add documentation in `DOCS.md`.