### PR TITLE
Rename schedules

### DIFF
--- a/src/components/common/EventChip.vue
+++ b/src/components/common/EventChip.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="event">
     <div class="name" :class="direction">
-      <span>{{ name }}</span>
+      <div class="text">{{ name }}</div>
     </div>
     <div class="date">
       <span>{{ month }}</span>
@@ -60,14 +60,21 @@ export default {
     color: white
     font-size: .9em
 
+    .text
+      white-space: nowrap
+      overflow: hidden
+      text-overflow: ellipsis
+
     &.right
       right: 0
-      span
-        margin-left: var(--circle-radius)
+      .text
+        margin-left: calc(2*var(--circle-radius))
+        margin-right: calc(var(--circle-radius)/3)
 
     &.left
-      span
-        margin-right: var(--circle-radius)
+      .text
+        margin-right: calc(2*var(--circle-radius))
+        margin-left: calc(var(--circle-radius)/3)
 
   .date
     --border-width: 2px

--- a/src/components/common/HybridInfoModal.vue
+++ b/src/components/common/HybridInfoModal.vue
@@ -1,22 +1,22 @@
 <template>
-  <div v-if="scheduleType === 'Hybrid' || scheduleType === 'Remote Hybrid' || scheduleType === 'Hybrid (Wed.)'">
+  <div v-if="scheduleType === 'Patriot Hybrid' || scheduleType === 'Remote Learning'">
     <div class="info-circle" @click="openModal()">
       <font-awesome-icon :icon="icons.faQuestionCircle" fixed-width />
     </div>
 
     <transition name="fade">
       <div v-if="showModal" class="modal" @click="closeModal()">
-        <div class="modal-content">
+        <div class="modal-content" @click.stop="">
           <div class="title">Schedule Information</div>
           <div class="divider" />
           <p>
-            "Remote Hybrid" means the schedule of hybrid learning but
+            "Remote Learning" means the schedule of hybrid learning but
             <b>only</b> online. This schedule is applicable for the weeks of Jan.
-            5 and Jan. 11
+            5 and Jan. 11 and on every Wednesday.
           </p>
           <div class="divider" />
           <p>
-            "Hybrid" means simultaneous on campus and online learning based on the
+            "Patriot Hybrid" means simultaneous on campus and online learning based on the
             3 color schedule. This schedule is planned to begin Jan. 19
           </p>
         </div>

--- a/src/components/common/cards/HybridCard.vue
+++ b/src/components/common/cards/HybridCard.vue
@@ -57,8 +57,7 @@ export default {
   computed: {
     show() {
       return (
-        this.bell.type === "Hybrid"
-        && this.date.getDay() !== 3
+        this.bell.type === "Patriot Hybrid"
         && this.bell.school
         && this.getCycleIndex() >= 0
       );
@@ -110,7 +109,7 @@ export default {
 .title
   text-align: center
   font-size: 1.5em
-  margin: 3px 0
+  margin: 10px 0
 
 .row
   border-radius: 40px

--- a/src/data/schedules.json
+++ b/src/data/schedules.json
@@ -1,7 +1,6 @@
-[
-	
+[	
 	{
-		"name": "Hybrid",
+		"name": "Patriot Hybrid",
 		"isSpecial": false,
 		"dates": [
 			"Weekdays"
@@ -36,7 +35,7 @@
 					"2",
 					"3",
 					"4",
-					"Break",
+					"!Break",
 					"5",
 					"6",
 					"7",
@@ -46,11 +45,12 @@
 		]
 	},
 	{
-		"name": "Remote Hybrid",
+		"name": "Remote Learning",
 		"isSpecial": true,
 		"dates": [
 			"1/5/2021-1/8/2021",
-			"1/11/2021-1/15/2021"
+			"1/11/2021-1/15/2021",
+			"wednesdays"
 		],
 		"modes": [
 			{
@@ -82,7 +82,7 @@
 					"2",
 					"3",
 					"4",
-					"Break",
+					"!Lunch",
 					"5",
 					"6",
 					"7",
@@ -91,52 +91,6 @@
 			}
 		]
 	},
-	{
-		"name": "Hybrid (Wed.)",
-		"isSpecial": false,
-		"dates": [
-			"1/18/21-1/1/2022 & Wednesday"
-		],
-		"modes": [
-			{
-				"name": "Normal",
-				"start": [
-					"8:35",
-					"9:25",
-					"10:15",
-					"11:05",
-					"11:45",
-					"12:15",
-					"13:05",
-					"13:55",
-					"14:45"
-				],
-				"end": [
-					"9:15",
-					"10:05",
-					"10:55",
-					"11:45",
-					"12:15",
-					"12:55",
-					"13:45",
-					"14:35",
-					"15:25"
-				],
-				"periods": [
-					"1",
-					"2",
-					"3",
-					"4",
-					"Lunch",
-					"5",
-					"6",
-					"7",
-					"8"
-				]
-			}
-		]
-	},
-
 	{
 		"name": "Late Arrival",
 		"isSpecial": true,
@@ -187,7 +141,7 @@
 		]
 	},
 	{
-		"name": "Finals (EL)",
+		"name": "Finals",
 		"isSpecial": true,
 		"dates": [
 			"12/14/2020-12/16/2020"


### PR DESCRIPTION
- Renamed `Hybrid` 🡒 `Patriot Hybrid` and `Remote Hybrid` 🡒 `Remote Learning` for clarity since `Remote Hybrid` sounds somewhat contradictory as "Hybrid" suggests that there are both online and in person components. This also matches the terminology used in the [google doc](https://docs.google.com/document/d/165sRjadprXE59ZW8MckV1Q7ZWIT9Ho91KvkQyWZ1sww/edit): ![image](https://user-images.githubusercontent.com/22779056/103571218-1fc20c00-4e90-11eb-8809-04f29b005de2.png)

- Removed `Hybrid (Wed.)` and just had `Remote Learning` also apply on Wednesdays since they seem to be the same schedule