### PR TITLE
Edge cases for remote schedule

### DIFF
--- a/src/components/common/HybridInfoModal.vue
+++ b/src/components/common/HybridInfoModal.vue
@@ -12,7 +12,7 @@
           <p>
             "Remote Learning" means the schedule similar to "Patriot Hybrid" but
             <b>only</b> online. This schedule is applicable for the weeks of Jan.
-            5 and Jan. 11 and on every Wednesday.
+            5 and Jan. 11 and on every Wednesday except the Wednesdays of 1/20/2021 and 2/17/2021 where the "Patriot Hybrid" schedule applies.
           </p>
           <div class="divider" />
           <p>

--- a/src/components/common/cards/HybridCard.vue
+++ b/src/components/common/cards/HybridCard.vue
@@ -70,13 +70,17 @@ export default {
       const curDate = startDate;
       while (curDate <= endDate) {
         const dayOfWeek = curDate.getDay();
-        if (!(dayOfWeek === 6 || dayOfWeek === 0 || dayOfWeek === 3)) count++;
+        
+        const dd = curDate.getDate() //temp
+        const mm =  curDate.getMonth() //temp
+        if (!(dd == 16 && mm == 1) && (!(dayOfWeek === 6 || dayOfWeek === 0 || dayOfWeek === 3) || (dd == 20 && mm == 0) ||  (dd == 17 && mm == 1))) count++; //TEMP: these are edge cases for the schedule
+        // if (!(dayOfWeek === 6 || dayOfWeek === 0 || dayOfWeek === 3)) count++;
         curDate.setDate(curDate.getDate() + 1);
       }
       return count;
     },
     getCycleIndex() {
-      const calibration = { date: new Date("January 19, 2021"), cycleDay: 2 }; // calibration date and corresponding cyclic day (1-12)
+      const calibration = { date: new Date("January 19, 2021"), cycleDay: 1 }; // calibration date and corresponding cyclic day (1-12)
       if (this.date < calibration.date) {
         return -1;
       }

--- a/src/data/schedules.json
+++ b/src/data/schedules.json
@@ -3,6 +3,7 @@
 		"name": "Patriot Hybrid",
 		"isSpecial": false,
 		"dates": [
+			"1/20/2021",
 			"Weekdays"
 		],
 		"modes": [
@@ -50,7 +51,7 @@
 		"dates": [
 			"1/5/2021-1/8/2021",
 			"1/11/2021-1/15/2021",
-			"wednesdays"
+			"wednesdays & !1/20/2021 & !2/17/2021"
 		],
 		"modes": [
 			{


### PR DESCRIPTION
the plot thickens 🤦🏻‍♂️ 
this update takes care of the special cases of the Monday being no school pushing the 4 day week to be all "patriot hybrid". My logic ensures 1/20/2021 and 2/17/2021 which are the Wednesdays of those special case weeks are shown as "patriot hybrid" not "remote learning" and keep the 3 color schedule in check. Thanks

<img width="543" alt="firstWeek" src="https://user-images.githubusercontent.com/31457361/103600237-8fee8300-4ecc-11eb-858b-316ca7eb4b5c.png">

![special-case-wednesday](https://user-images.githubusercontent.com/31457361/103600658-8ca7c700-4ecd-11eb-952f-098ae032f1e1.png)
